### PR TITLE
use node v8 for ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: false
 jdk:
 - oraclejdk8
-node_js: stable
+node_js: "8"
 matrix:
   allow_failures:
   - env: CMD=test:sauce

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: false
 jdk:
 - oraclejdk8
-node_js: "8"
+node_js: "lts/*"
 matrix:
   allow_failures:
   - env: CMD=test:sauce


### PR DESCRIPTION
fix yarn incompatible

```
$ yarn
yarn install v1.3.2
(node:3480) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
[1/4] Resolving packages...
[2/4] Fetching packages...
error upath@1.0.4: The engine "node" is incompatible with this module. Expected version ">=4 <=9".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```